### PR TITLE
Update hyper to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "static-server"
-version = "0.0.11"
+version = "0.0.12"
 authors = ["Denis Kolodin <deniskolodin@gmail.com>"]
 description = "Library for serve static files by HTTP"
 repository = "https://github.com/DenisKolodin/static-server"
@@ -16,6 +16,6 @@ log = "0.3.6"
 env_logger = "0.3.5"
 mime_guess = "1.8.1"
 mime = "0.2.2"
-hyper = "0.9.14"
+hyper = "0.10"
 tar = "0.4.9"
 


### PR DESCRIPTION
This removes the dep on openssl, which static-server doesn't use.